### PR TITLE
Add 'ruok' check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,11 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachangelog.com/)
 
-## Unreleased][unreleased]
+## [Unreleased]
+
+## [0.1.0] - 2016-01-06
+### Added
+- check-zookeeper-ruok
 
 ## [0.0.4] - 2015-12-10
 ### Added

--- a/bin/check-zookeeper-ruok.rb
+++ b/bin/check-zookeeper-ruok.rb
@@ -1,10 +1,15 @@
-#! /usr/bin/env ruby
+#!/usr/bin/env ruby
 #  encoding: UTF-8
 #
 #  check-zookeeper-ruok
 #
 # DESCRIPTION:
-#   check if zookeeper node responds with imok
+#   Check if Zookeeper node responds to 'ruok' query succesfully.
+#
+#   'ruok' is a ZooKeeper four letter word command (short for Are You Okay?)
+#   Specifically ruok tests if the server is running in a non-error state.
+#   The server will respond with imok if it is running. Otherwise it will
+#   not respond at all.
 #
 # PLATFORMS:
 #   All
@@ -13,10 +18,10 @@
 #   gem: sensu-plugin
 #
 # USAGE:
-#  check if a node has zookeeper running and responds with imok
-#  ./check-zookeeepr-ruok.rb # Equivalent to examples below
-#  ./check-zookeeepr-ruok.rb -s localhost -p 2181
-#  ./check-zookeeepr-ruok.rb --server localhost --port 2181
+#  Check if a node has Zookeeper running and responds with imok.
+#  ./check-zookeeeper-ruok.rb # Equivalent to examples below
+#  ./check-zookeeeper-ruok.rb -s localhost -p 2181
+#  ./check-zookeeeper-ruok.rb --server localhost --port 2181
 #
 # LICENCE:
 #   Phil Grayson <phil@philgrayson.com>
@@ -29,21 +34,21 @@ require 'socket'
 
 class CheckZookeeperRUOK < Sensu::Plugin::Check::CLI
   option :server,
-         description: 'zookeeper hostname to connect to',
+         description: 'Zookeeper hostname to connect to.',
          short: '-s HOSTNAME',
          long: '--server HOSTNAME',
          default: 'localhost'
 
   option :port,
-         description: 'zk port to connect to',
+         description: 'Zookeeper port to connect to.',
          short: '-p PORT',
          long: '--port PORT',
          default: 2181
 
   option :timeout,
-         description: 'how long to wait for a reply in seconds',
-         short: '-t TIMEOUT',
-         long: '--timeout PORT',
+         description: 'How long to wait for a reply in seconds.',
+         short: '-t SECS',
+         long: '--timeout SECS',
          proc: proc(&:to_i),
          default: 5
 

--- a/bin/check-zookeeper-ruok.rb
+++ b/bin/check-zookeeper-ruok.rb
@@ -63,8 +63,8 @@ class CheckZookeeperRUOK < Sensu::Plugin::Check::CLI
 
       result = ready.first.first.read.chomp
 
-      ok %(Got '#{result}') if result == 'imok'
-      critical %(Got '#{result}')
+      ok 'Zookeeper reports no errors' if result == 'imok'
+      critical %(Zookeeper returned a non okay message: '#{result}')
     end
   end
 end

--- a/bin/check-zookeeper-ruok.rb
+++ b/bin/check-zookeeper-ruok.rb
@@ -1,0 +1,65 @@
+#! /usr/bin/env ruby
+#  encoding: UTF-8
+#
+#  check-zookeeper-ruok
+#
+# DESCRIPTION:
+#   check if zookeeper node responds with imok
+#
+# PLATFORMS:
+#   All
+#
+# DEPENDENCIES:
+#   gem: sensu-plugin
+#
+# USAGE:
+#  check if a node has zookeeper running and responds with imok
+#  ./check-zookeeepr-ruok.rb # Equivalent to examples below
+#  ./check-zookeeepr-ruok.rb -s localhost -p 2181
+#  ./check-zookeeepr-ruok.rb --server localhost --port 2181
+#
+# LICENCE:
+#   Phil Grayson <phil@philgrayson.com>
+#   Released under the same terms as Sensu (the MIT license); see LICENSE
+#   for details.
+#
+
+require 'sensu-plugin/check/cli'
+require 'socket'
+
+class CheckZookeeperRUOK < Sensu::Plugin::Check::CLI
+  option :server,
+         description: 'zookeeper hostname to connect to',
+         short: '-s HOSTNAME',
+         long: '--server HOSTNAME',
+         default: 'localhost'
+
+  option :port,
+         description: 'zk port to connect to',
+         short: '-p PORT',
+         long: '--port PORT',
+         default: 2181
+
+  option :timeout,
+         description: 'how long to wait for a reply in seconds',
+         short: '-t TIMEOUT',
+         long: '--timeout PORT',
+         proc: proc(&:to_i),
+         default: 5
+
+  def run
+    TCPSocket.open(config[:server], config[:port]) do |socket|
+      socket.write 'ruok'
+      ready = IO.select([socket], nil, nil, config[:timeout])
+
+      if ready.nil?
+        critical %(Zookeeper did not respond to 'ruok' within #{config[:timeout]} seconds)
+      end
+
+      result = ready.first.first.read.chomp
+
+      ok %(Got '#{result}') if result == 'imok'
+      critical %(Got '#{result}')
+    end
+  end
+end

--- a/lib/sensu-plugins-zookeeper/version.rb
+++ b/lib/sensu-plugins-zookeeper/version.rb
@@ -1,8 +1,8 @@
 module SensuPluginsZookeeper
   module Version
     MAJOR = 0
-    MINOR = 0
-    PATCH = 4
+    MINOR = 1
+    PATCH = 0
 
     VER_STRING = [MAJOR, MINOR, PATCH].compact.join('.')
   end


### PR DESCRIPTION
Tests if a Zookeeper node responses with 'imok' when asked 'ruok'. Raises a critical if nothing other than 'imok' is returned.

Note: I added a timeout flag for this check despite Sensu core already having a timeout for checks.
The reason is I forgot to add an explicit timeout during testing of this check. The check ran on a Zookeeper node that never responded to 'ruok' (despite still accepting connections), resulting in Sensu waiting forever for the check to return.
This caused a knock on effect where the Sensu client couldn't be restarted. I had to add the timeout, kill the check process and restart Sensu to fix.

Using the Sensu core timeout works as expected, if you remember to configure one! I'm happy to remove the timeout flag and update the check docs to recommend using a timeout if you think the flag should be removed.