### PR TITLE
Checks for ZK outstanding requests, average latency and opened file descriptors ratio

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,6 @@ deploy:
   on:
     tags: true
     all_branches: true
-    rvm: 1.9.3
     rvm: 2.0
     rvm: 2.1
     rvm: 2.2

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ cache:
 install:
 - bundle install
 rvm:
-- 1.9.3
 - 2.0
 - 2.1
 - 2.2

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,13 +4,14 @@ cache:
 install:
 - bundle install
 rvm:
+- 1.9.3
 - 2.0
 - 2.1
 - 2.2
 notifications:
   email:
     recipients:
-    - yrochnyak@gmail.com
+    - sensu-plugin@sensu-plugins.io
     on_success: change
     on_failure: always
 script:
@@ -25,7 +26,8 @@ deploy:
   on:
     tags: true
     all_branches: true
+    rvm: 1.9.3
     rvm: 2.0
     rvm: 2.1
     rvm: 2.2
-    repo: grem11n/sensu-plugins-zookeeper
+    repo: sensu-plugins/sensu-plugins-zookeeper

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ rvm:
 notifications:
   email:
     recipients:
-    - sensu-plugin@sensu-plugins.io
+    - yrochnyak@gmail.com
     on_success: change
     on_failure: always
 script:
@@ -30,4 +30,4 @@ deploy:
     rvm: 2.0
     rvm: 2.1
     rvm: 2.2
-    repo: sensu-plugins/sensu-plugins-zookeeper
+    repo: grem11n/sensu-plugins-zookeeper

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ rvm:
 notifications:
   email:
     recipients:
-    - sensu-plugin@sensu-plugins.io
+    - yrochnyak@gmail.com
     on_success: change
     on_failure: always
 script:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachangelog.com/)
 
 ## [Unreleased]
+### Aded
+- check-zookeeper-reqs
+- check-zookeeper-latency
+- check-zookeeper-file-descriptors
 
 ## [0.1.0] - 2016-03-05
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachangelog.com/)
 
-## [Unreleased]
+## [Unreleased] = 2017-02-28
 ### Aded
 - check-zookeeper-reqs
 - check-zookeeper-latency

--- a/bin/check-zookeeper-file-descriptors.rb
+++ b/bin/check-zookeeper-file-descriptors.rb
@@ -1,0 +1,80 @@
+#!/usr/bin/env ruby
+#  encoding: UTF-8
+#
+#  check-zookeeper-file-descriptors.rb
+#
+# DESCRIPTION:
+#   Check if Zookeeper has normal opened file descriptors rate.
+#
+#   'mntr' is a ZooKeeper four letter word command, which outputs
+#   a list of variables that could be used for monitoring
+#   the health of the cluster.
+#
+#   Specifically file-descriptors.rb tests if the server has normal amount of opened file descriptors.
+#   Opened file descriptors rate is defined as (AVG_amount / MAX_amount).
+#
+# PLATFORMS:
+#   All
+#
+# DEPENDENCIES:
+#   gem: sensu-plugin
+#
+# USAGE:
+#  Check if a node has Zookeeper running and responds with imok.
+#  ./check-zookeeeper-file-descriptors.rb.rb # Equivalent to examples below
+#  ./check-zookeeeper-file-descriptors.rb.rb -s localhost -p 2181 -d 0.85
+#  ./check-zookeeeper-file-descriptors.rb.rb --server localhost --port 2181 --file-descriptors 0.85
+#
+# LICENCE:
+#   Phil Grayson <phil@philgrayson.com>
+#   Released under the same terms as Sensu (the MIT license); see LICENSE
+#   for details.
+#
+
+require 'sensu-plugin/check/cli'
+require 'socket'
+
+class CheckZookeeperREQS < Sensu::Plugin::Check::CLI
+  option :server,
+	 description: 'Zookeeper hostname to connect to.',
+	 short: '-s HOSTNAME',
+	 long: '--server HOSTNAME',
+	 default: 'localhost'
+
+  option :port,
+	 description: 'Zookeeper port to connect to.',
+	 short: '-p PORT',
+	 long: '--port PORT',
+	 default: 2181
+
+  option :timeout,
+	 description: 'How long to wait for a reply in seconds.',
+	 short: '-t SECS',
+	 long: '--timeout SECS',
+	 proc: proc(&:to_i),
+	 default: 5
+
+  option :fd_critical,
+	 description: 'Critical threshold for Zookeeper open files descriptors',
+	 short: '-d DESCRIPTORS',
+	 long: '--file-descriptors DESCRIPTORS',
+	 proc: proc(&:to_f),
+	 default: 0.85
+
+  def run
+    TCPSocket.open(config[:server], config[:port]) do |socket|
+      socket.write 'mntr'
+      ready = IO.select([socket], nil, nil, config[:timeout])
+
+      if ready.nil?
+	critical %(Zookeeper did not respond to 'mntr' within #{config[:timeout]} seconds)
+      end
+
+      result = ready.first.first.read.chomp.split("\n")
+      avg_fd = (result[13].split("\t")[1].to_f / result[14].split("\t")[1].to_f)
+
+      ok "Zookeeper's open file descriptors rate is #{avg_fd}" if (avg_fd < config[:fd_critical])
+      critical %(Zookeeper's open file descriptors rate is #{avg_fd}, which is more than #{config[:fd_critical]} threshold)
+    end
+  end
+end

--- a/bin/check-zookeeper-file-descriptors.rb
+++ b/bin/check-zookeeper-file-descriptors.rb
@@ -36,30 +36,30 @@ require 'socket'
 
 class CheckZookeeperREQS < Sensu::Plugin::Check::CLI
   option :server,
-	 description: 'Zookeeper hostname to connect to.',
-	 short: '-s HOSTNAME',
-	 long: '--server HOSTNAME',
-	 default: 'localhost'
+         description: 'Zookeeper hostname to connect to.',
+         short: '-s HOSTNAME',
+         long: '--server HOSTNAME',
+         default: 'localhost'
 
   option :port,
-	 description: 'Zookeeper port to connect to.',
-	 short: '-p PORT',
-	 long: '--port PORT',
-	 default: 2181
+         description: 'Zookeeper port to connect to.',
+         short: '-p PORT',
+         long: '--port PORT',
+         default: 2181
 
   option :timeout,
-	 description: 'How long to wait for a reply in seconds.',
-	 short: '-t SECS',
-	 long: '--timeout SECS',
-	 proc: proc(&:to_i),
-	 default: 5
+         description: 'How long to wait for a reply in seconds.',
+         short: '-t SECS',
+         long: '--timeout SECS',
+         proc: proc(&:to_i),
+         default: 5
 
   option :fd_critical,
-	 description: 'Critical threshold for Zookeeper open files descriptors',
-	 short: '-d DESCRIPTORS',
-	 long: '--file-descriptors DESCRIPTORS',
-	 proc: proc(&:to_f),
-	 default: 0.85
+         description: 'Critical threshold for Zookeeper open files descriptors',
+         short: '-d DESCRIPTORS',
+         long: '--file-descriptors DESCRIPTORS',
+         proc: proc(&:to_f),
+         default: 0.85
 
   def run
     TCPSocket.open(config[:server], config[:port]) do |socket|
@@ -67,13 +67,13 @@ class CheckZookeeperREQS < Sensu::Plugin::Check::CLI
       ready = IO.select([socket], nil, nil, config[:timeout])
 
       if ready.nil?
-	critical %(Zookeeper did not respond to 'mntr' within #{config[:timeout]} seconds)
+        critical %(Zookeeper did not respond to 'mntr' within #{config[:timeout]} seconds)
       end
 
       result = ready.first.first.read.chomp.split("\n")
       avg_fd = (result[13].split("\t")[1].to_f / result[14].split("\t")[1].to_f)
 
-      ok "Zookeeper's open file descriptors rate is #{avg_fd}" if (avg_fd < config[:fd_critical])
+      ok "Zookeeper's open file descriptors rate is #{avg_fd}" if avg_fd < config[:fd_critical]
       critical %(Zookeeper's open file descriptors rate is #{avg_fd}, which is more than #{config[:fd_critical]} threshold)
     end
   end

--- a/bin/check-zookeeper-latency.rb
+++ b/bin/check-zookeeper-latency.rb
@@ -7,7 +7,7 @@
 #   Check average latency on Zookeeper node.
 #
 #   'mntr' is a ZooKeeper four letter word command, which outputs
-#   Specifically latency is an amount of time it takes for the server 
+#   Specifically latency is an amount of time it takes for the server
 #   to respond to a client request (since the server was started).
 #
 # PLATFORMS:
@@ -70,7 +70,7 @@ class CheckZookeeperREQS < Sensu::Plugin::Check::CLI
       result = ready.first.first.read.chomp.split("\n")
       avg_latency = result[1].split("\t")[1].to_i
 
-      ok "Zookeeper has average latency #{avg_latency}" if (avg_latency < config[:avg_latency_critical])
+      ok "Zookeeper has average latency #{avg_latency}" if avg_latency < config[:avg_latency_critical]
       critical %(Zookeeper's average latency is #{avg_latency}, which is more than #{config[:avg_latency_critical]} threshold)
     end
   end

--- a/bin/check-zookeeper-latency.rb
+++ b/bin/check-zookeeper-latency.rb
@@ -1,0 +1,77 @@
+#!/usr/bin/env ruby
+#  encoding: UTF-8
+#
+#  check-zookeeper-latency
+#
+# DESCRIPTION:
+#   Check average latency on Zookeeper node.
+#
+#   'mntr' is a ZooKeeper four letter word command, which outputs
+#   Specifically latency is an amount of time it takes for the server 
+#   to respond to a client request (since the server was started).
+#
+# PLATFORMS:
+#   All
+#
+# DEPENDENCIES:
+#   gem: sensu-plugin
+#
+# USAGE:
+#  Check if a node has Zookeeper running and responds with imok.
+#  ./check-zookeeeper-latency.rb # Equivalent to examples below
+#  ./check-zookeeeper-latency.rb -s localhost -p 2181 -l 10
+#  ./check-zookeeeper-latency.rb --server localhost --port 2181 --latency 10
+#
+# LICENCE:
+#   Phil Grayson <phil@philgrayson.com>
+#   Released under the same terms as Sensu (the MIT license); see LICENSE
+#   for details.
+#
+
+require 'sensu-plugin/check/cli'
+require 'socket'
+
+class CheckZookeeperREQS < Sensu::Plugin::Check::CLI
+  option :server,
+         description: 'Zookeeper hostname to connect to.',
+         short: '-s HOSTNAME',
+         long: '--server HOSTNAME',
+         default: 'localhost'
+
+  option :port,
+         description: 'Zookeeper port to connect to.',
+         short: '-p PORT',
+         long: '--port PORT',
+         default: 2181
+
+  option :timeout,
+         description: 'How long to wait for a reply in seconds.',
+         short: '-t SECS',
+         long: '--timeout SECS',
+         proc: proc(&:to_i),
+         default: 5
+
+  option :avg_latency_critical,
+         description: 'Critical threshold for Zookeeper average latency',
+         short: '-l TICKS',
+         long: '--latency TICKS',
+         proc: proc(&:to_i),
+         default: 10
+
+  def run
+    TCPSocket.open(config[:server], config[:port]) do |socket|
+      socket.write 'mntr'
+      ready = IO.select([socket], nil, nil, config[:timeout])
+
+      if ready.nil?
+        critical %(Zookeeper did not respond to 'mntr' within #{config[:timeout]} seconds)
+      end
+
+      result = ready.first.first.read.chomp.split("\n")
+      avg_latency = result[1].split("\t")[1].to_i
+
+      ok "Zookeeper has average latency #{avg_latency}" if (avg_latency < config[:avg_latency_critical])
+      critical %(Zookeeper's average latency is #{avg_latency}, which is more than #{config[:avg_latency_critical]} threshold)
+    end
+  end
+end

--- a/bin/check-zookeeper-reqs.rb
+++ b/bin/check-zookeeper-reqs.rb
@@ -73,7 +73,7 @@ class CheckZookeeperREQS < Sensu::Plugin::Check::CLI
       result = ready.first.first.read.chomp.split("\n")
       out_reqs = result[7].split("\t")[1].to_i
 
-      ok "Zookeeper has #{out_reqs} outstanding requests" if (out_reqs < config[:out_reqs_critical])
+      ok "Zookeeper has #{out_reqs} outstanding requests" if out_reqs < config[:out_reqs_critical]
       critical %(Zookeeper has #{out_reqs} outstanding requests, which is more than #{config[:out_reqs_critical]} threshold)
     end
   end

--- a/bin/check-zookeeper-reqs.rb
+++ b/bin/check-zookeeper-reqs.rb
@@ -1,0 +1,80 @@
+#!/usr/bin/env ruby
+#  encoding: UTF-8
+#
+#  check-zookeeper-reqs
+#
+# DESCRIPTION:
+#   Check if Zookeeper node has reliable number of outstanding requests.
+#
+#   'mntr' is a ZooKeeper four letter word command, which outputs
+#   a list of variables that could be used for monitoring
+#   the health of the cluster
+#
+#   This check verifies if Zookeeper is not overwhelemed with requests
+#   that it cannot proceed
+#
+# PLATFORMS:
+#   All
+#
+# DEPENDENCIES:
+#   gem: sensu-plugin
+#
+# USAGE:
+#  Check if Zookeeper doesn't have a lot of outstanding requests
+#  ./check-zookeeeper-reqs.rb # Equivalent to examples below
+#  ./check-zookeeeper-reqs.rb -s localhost -p 2181 -r 10
+#  ./check-zookeeeper-reqs.rb --server localhost --port 2181 --reqs 10
+#
+# LICENCE:
+#   Phil Grayson <phil@philgrayson.com>
+#   Released under the same terms as Sensu (the MIT license); see LICENSE
+#   for details.
+#
+
+require 'sensu-plugin/check/cli'
+require 'socket'
+
+class CheckZookeeperREQS < Sensu::Plugin::Check::CLI
+  option :server,
+         description: 'Zookeeper hostname to connect to.',
+         short: '-s HOSTNAME',
+         long: '--server HOSTNAME',
+         default: 'localhost'
+
+  option :port,
+         description: 'Zookeeper port to connect to.',
+         short: '-p PORT',
+         long: '--port PORT',
+         default: 2181
+
+  option :timeout,
+         description: 'How long to wait for a reply in seconds.',
+         short: '-t SECS',
+         long: '--timeout SECS',
+         proc: proc(&:to_i),
+         default: 5
+
+  option :out_reqs_critical,
+         description: 'Critical threshold for Zookeeper outstanding requests',
+         short: '-r REQS',
+         long: '--reqs REQS',
+         proc: proc(&:to_i),
+         default: 10
+
+  def run
+    TCPSocket.open(config[:server], config[:port]) do |socket|
+      socket.write 'mntr'
+      ready = IO.select([socket], nil, nil, config[:timeout])
+
+      if ready.nil?
+        critical %(Zookeeper did not respond to 'mntr' within #{config[:timeout]} seconds)
+      end
+
+      result = ready.first.first.read.chomp.split("\n")
+      out_reqs = result[7].split("\t")[1].to_i
+
+      ok "Zookeeper has #{out_reqs} outstanding requests" if (out_reqs < config[:out_reqs_critical])
+      critical %(Zookeeper has #{out_reqs} outstanding requests, which is more than #{config[:out_reqs_critical]} threshold)
+    end
+  end
+end


### PR DESCRIPTION
## Pull Request Checklist

**Is this in reference to an existing issue?**
No, just a few new checks

#### General

- [x] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

- [ ] Update README with any necessary configuration snippets

- [ ] Binstubs are created if needed

- [ ] RuboCop passes

- [ ] Existing tests pass 

#### New Plugins

- [ ] Tests

- [ ] Add the plugin to the README

- [x] Does it have a complete header as outlined [here](http://sensu-plugins.io/docs/developer_guidelines.html#coding-style)

#### Purpose
These are checks for Zookeeper outstanding requests, average latency and opened file descriptor count ratio.
Thresholds were defined based on David Mytton's [article](https://blog.serverdensity.com/how-to-monitor-zookeeper/) on Zookeeper monitoring.

#### Known Compatablity Issues
Checks were tested against Zookeeper version: 3.4.6
Checks should work with Zookeeper version >= 3.4.0, since 'mntr' four letter word was introduced in this version.

