### PR TITLE
Increase rubocop version to `0.51.x` & remove Ruby 2.0 testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ mkmf.log
 .DS_Store
 .idea/*
 *.gem
+/vendor/

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ cache:
 install:
 - bundle install
 rvm:
-- 2.0
 - 2.1
 - 2.2
 - 2.3.0
@@ -27,7 +26,6 @@ deploy:
   on:
     tags: true
     all_branches: true
-    rvm: 2.0
     rvm: 2.1
     rvm: 2.2
     rvm: 2.3.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ This CHANGELOG follows the format listed at [Our CHANGELOG Guidelines ](https://
 Which is based on [Keep A Changelog](http://keepachangelog.com/)
 
 ## [Unreleased]
+### Security
+- updated rubocop dependency to `~> 0.51.0` per: https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-8418. (@thomasriley)
+
+### Breaking Changes
+- removed < ruby 2.1 support which was pulled as part of security updates (@thomasriley)
 
 ## [1.5.0] - 2017-12-06
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ Which is based on [Keep A Changelog](http://keepachangelog.com/)
 ### Breaking Changes
 - removed < ruby 2.1 support which was pulled as part of security updates (@thomasriley)
 
+### Changed
+- Various amendments to comply with Rubocop (@thomasriley)
+
 ## [1.5.0] - 2017-12-06
 ### Added
 - check-netty-zookeeper-cluster.rb: new script to check if a zookeeper v. 3.5 cluster is OK (@duncaan)

--- a/Rakefile
+++ b/Rakefile
@@ -7,9 +7,9 @@ require 'yard'
 require 'yard/rake/yardoc_task'
 
 YARD::Rake::YardocTask.new do |t|
-  OTHER_PATHS = %w().freeze
+  OTHER_PATHS = %w[].freeze
   t.files = ['lib/**/*.rb', 'bin/**/*.rb', OTHER_PATHS]
-  t.options = %w(--markup-provider=redcarpet --markup=markdown --main=README.md --files CHANGELOG.md)
+  t.options = %w[--markup-provider=redcarpet --markup=markdown --main=README.md --files CHANGELOG.md]
 end
 
 RuboCop::RakeTask.new
@@ -35,4 +35,4 @@ task :check_binstubs do
   end
 end
 
-task default: [:spec, :make_bin_executable, :yard, :rubocop, :check_binstubs]
+task default: %i[spec make_bin_executable yard rubocop check_binstubs]

--- a/bin/check-netty-zookeeper-cluster.rb
+++ b/bin/check-netty-zookeeper-cluster.rb
@@ -1,5 +1,4 @@
 #!/usr/bin/env ruby
-#  encoding: UTF-8
 
 #
 #  netty-check-zookeeper-cluster

--- a/bin/check-znode.rb
+++ b/bin/check-znode.rb
@@ -1,5 +1,4 @@
 #! /usr/bin/env ruby
-#  encoding: UTF-8
 #
 #  check-znode
 #

--- a/bin/check-zookeeper-cluster.rb
+++ b/bin/check-zookeeper-cluster.rb
@@ -1,5 +1,4 @@
 #!/usr/bin/env ruby
-#  encoding: UTF-8
 #
 #  check-zookeeper-cluster
 #

--- a/bin/check-zookeeper-file-descriptors.rb
+++ b/bin/check-zookeeper-file-descriptors.rb
@@ -1,5 +1,4 @@
 #!/usr/bin/env ruby
-#  encoding: UTF-8
 #
 #  check-zookeeper-file-descriptors.rb
 #

--- a/bin/check-zookeeper-latency.rb
+++ b/bin/check-zookeeper-latency.rb
@@ -1,5 +1,4 @@
 #!/usr/bin/env ruby
-#  encoding: UTF-8
 #
 #  check-zookeeper-latency
 #

--- a/bin/check-zookeeper-mode.rb
+++ b/bin/check-zookeeper-mode.rb
@@ -1,5 +1,4 @@
 #!/usr/bin/env ruby
-#  encoding: UTF-8
 #
 #  check-zookeeper-mode
 #

--- a/bin/check-zookeeper-reqs.rb
+++ b/bin/check-zookeeper-reqs.rb
@@ -1,5 +1,4 @@
 #!/usr/bin/env ruby
-#  encoding: UTF-8
 #
 #  check-zookeeper-reqs
 #

--- a/bin/check-zookeeper-ruok.rb
+++ b/bin/check-zookeeper-ruok.rb
@@ -1,5 +1,4 @@
 #!/usr/bin/env ruby
-#  encoding: UTF-8
 #
 #  check-zookeeper-ruok
 #

--- a/bin/metrics-zookeeper-cluster.rb
+++ b/bin/metrics-zookeeper-cluster.rb
@@ -122,6 +122,7 @@ class ZookeeperMetrics < Sensu::Plugin::Metric::CLI::Graphite
 
     json = exhibitor_status
 
+    # TODO: Need to shortern this function
     # rubocop:disable Metrics/BlockLength
     json.each do |zk|
       hostname = zk['hostname']

--- a/bin/metrics-zookeeper-cluster.rb
+++ b/bin/metrics-zookeeper-cluster.rb
@@ -49,9 +49,10 @@ class ZookeeperMetrics < Sensu::Plugin::Metric::CLI::Graphite
          default: 2181,
          proc: proc(&:to_i)
 
-  # TODO: Remove rubocop:disable Style/CommentedKeyword on this function when fixed (https://github.com/sensu-plugins/community/issues/77#issuecomment-345813238)
-  # rubocop:disable Style/CommentedKeyword
-  def follow_url(uri_str, agent = "sensu-plugins-zookeeper/#{SensuPluginsZookeeper::Version::VER_STRING}", max_attempts = 10, timeout = 10)
+  def follow_url(uri_str,
+                 agent = "sensu-plugins-zookeeper/#{SensuPluginsZookeeper::Version::VER_STRING}",
+                 max_attempts = 10,
+                 timeout = 10)
     attempts = 0
     cookie = nil
 

--- a/bin/metrics-zookeeper-cluster.rb
+++ b/bin/metrics-zookeeper-cluster.rb
@@ -49,7 +49,7 @@ class ZookeeperMetrics < Sensu::Plugin::Metric::CLI::Graphite
          default: 2181,
          proc: proc(&:to_i)
 
-  # TODO: Remove below when Rubocop is updated (https://github.com/sensu-plugins/community/issues/77#issuecomment-345813238)
+  # TODO: Remove rubocop:disable Style/CommentedKeyword on this function when fixed (https://github.com/sensu-plugins/community/issues/77#issuecomment-345813238)
   # rubocop:disable Style/CommentedKeyword
   def follow_url(uri_str, agent = "sensu-plugins-zookeeper/#{SensuPluginsZookeeper::Version::VER_STRING}", max_attempts = 10, timeout = 10)
     attempts = 0
@@ -97,6 +97,7 @@ class ZookeeperMetrics < Sensu::Plugin::Metric::CLI::Graphite
 
     response
   end
+  # rubocop:enable Style/CommentedKeyword
 
   def dotted(*args)
     args.join('.')
@@ -123,8 +124,7 @@ class ZookeeperMetrics < Sensu::Plugin::Metric::CLI::Graphite
     json = exhibitor_status
 
     # TODO: Need to shortern this function
-    # rubocop:disable Metrics/BlockLength
-    json.each do |zk|
+    json.each do |zk| # rubocop:disable Metrics/BlockLength
       hostname = zk['hostname']
       response  = zk_command(:mntr, hostname, config[:zk_port])
       metrics   = {}

--- a/bin/metrics-zookeeper-cluster.rb
+++ b/bin/metrics-zookeeper-cluster.rb
@@ -49,6 +49,8 @@ class ZookeeperMetrics < Sensu::Plugin::Metric::CLI::Graphite
          default: 2181,
          proc: proc(&:to_i)
 
+  # TODO: Remove below when Rubocop is updated (https://github.com/sensu-plugins/community/issues/77#issuecomment-345813238)
+  # rubocop:disable Style/CommentedKeyword
   def follow_url(uri_str, agent = "sensu-plugins-zookeeper/#{SensuPluginsZookeeper::Version::VER_STRING}", max_attempts = 10, timeout = 10)
     attempts = 0
     cookie = nil
@@ -119,6 +121,8 @@ class ZookeeperMetrics < Sensu::Plugin::Metric::CLI::Graphite
     timestamp = Time.now.to_i
 
     json = exhibitor_status
+
+    # rubocop:disable Metrics/BlockLength
     json.each do |zk|
       hostname = zk['hostname']
       response  = zk_command(:mntr, hostname, config[:zk_port])

--- a/sensu-plugins-zookeeper.gemspec
+++ b/sensu-plugins-zookeeper.gemspec
@@ -4,14 +4,14 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'date'
 require_relative 'lib/sensu-plugins-zookeeper'
 
-Gem::Specification.new do |s|
+Gem::Specification.new do |s| # rubocop:disable Metrics/BlockLength
   s.authors                = ['Sensu Plugins and contributors']
 
   s.date                   = Date.today.to_s
   s.description            = 'Zookeeper plugins for checks and metrics'
   s.email                  = '<sensu-users@googlegroups.com>'
   s.executables            = Dir.glob('bin/**/*.rb').map { |file| File.basename(file) }
-  s.files                  = Dir.glob('{bin,lib}/**/*') + %w(LICENSE README.md CHANGELOG.md)
+  s.files                  = Dir.glob('{bin,lib}/**/*') + %w[LICENSE README.md CHANGELOG.md]
   s.homepage               = 'https://github.com/sensu-plugins/sensu-plugins-zookeeper'
   s.license                = 'MIT'
   s.metadata               = { 'maintainer'         => 'sensu-plugin',
@@ -36,7 +36,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'pry',                       '~> 0.10'
   s.add_development_dependency 'rake',                      '~> 10.5'
   s.add_development_dependency 'redcarpet',                 '~> 3.2'
-  s.add_development_dependency 'rubocop',                   '~> 0.51.0'
   s.add_development_dependency 'rspec',                     '~> 3.4'
+  s.add_development_dependency 'rubocop',                   '~> 0.51.0'
   s.add_development_dependency 'yard',                      '~> 0.8'
 end

--- a/sensu-plugins-zookeeper.gemspec
+++ b/sensu-plugins-zookeeper.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   s.platform               = Gem::Platform::RUBY
   s.post_install_message   = 'You can use the embedded Ruby by setting EMBEDDED_RUBY=true in /etc/default/sensu'
   s.require_paths          = ['lib']
-  s.required_ruby_version  = '>= 2.0.0'
+  s.required_ruby_version  = '>= 2.1.0'
 
   s.summary                = 'Sensu plugins for zookeeper'
   s.test_files             = s.files.grep(%r{^(test|spec|features)/})
@@ -36,7 +36,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'pry',                       '~> 0.10'
   s.add_development_dependency 'rake',                      '~> 10.5'
   s.add_development_dependency 'redcarpet',                 '~> 3.2'
-  s.add_development_dependency 'rubocop',                   '~> 0.40.0'
+  s.add_development_dependency 'rubocop',                   '~> 0.51.0'
   s.add_development_dependency 'rspec',                     '~> 3.4'
   s.add_development_dependency 'yard',                      '~> 0.8'
 end


### PR DESCRIPTION
## Pull Request Checklist

sensu-plugins/community#77

#### General

- [x] Update Changelog following the conventions laid out on [Our CHANGELOG Guidelines ](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)

- [x] RuboCop passes

- [x] Existing tests pass

#### Purpose
Increase rubocop version for CVE. 

#### Known Compatibility Issues
Now requires Ruby 2.1 and greater