### PR TITLE
Option to check sub-nodes against regex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Which is based on [Keep A Changelog](http://keepachangelog.com/)
 
 ## [Unreleased]
 
+## [2.0.1] - 2019-06-05
+### Added
+- check-znode.rb: added flag of `--check_child|-c` to allow for checking for child node(s) against a regex. (@mattboston)
+
 ## [2.0.0] - 2018-01-18
 ### Security
 - updated rubocop dependency to `~> 0.51.0` per: https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-8418. (@thomasriley)

--- a/bin/check-znode.rb
+++ b/bin/check-znode.rb
@@ -51,7 +51,7 @@ class CheckZnode < Sensu::Plugin::Check::CLI
          long: '--check_value REGEX'
 
   option :check_child,
-         description: 'Optionally check for child node against a regex',
+         description: 'Optionally check sub-nodes against a regex',
          short: '-c',
          long: '--check_child REGEX'
   

--- a/bin/check-znode.rb
+++ b/bin/check-znode.rb
@@ -18,6 +18,7 @@
 # USAGE:
 #  check if znode /test exists with value starting with 'test'
 #  ./check-znode.rb -s localhost:2181 -z /test -v '^test.*'
+#  ./check-znode.rb -s localhost:2181 -z /test -c '^test.*'
 #
 # NOTES:
 #  Multiple zk servers are accepted, e.g. zk01:2181,zk02:2181,zk03:2181
@@ -49,14 +50,26 @@ class CheckZnode < Sensu::Plugin::Check::CLI
          short: '-v',
          long: '--check_value REGEX'
 
+  option :check_child,
+         description: 'Optionally check for child node against a regex',
+         short: '-c',
+         long: '--check_child REGEX'
+  
   def znode_status
     zk = Zookeeper.new(config[:server])
     znode = zk.get(path: config[:znode])
+    children = config[:check_child] ? "#{zk.get_children(path: config[:znode])[:children]}" : null
 
     if znode[:stat].exists?
       if config[:check_value]
         if Regexp.new(config[:check_value]).match(znode[:data])
           ok "#{config[:znode]} value matched regexp '#{config[:check_value]}'"
+        elsif config[:check_child]
+          if children.include?(config[:check_child])
+            ok "#{config[:znode]} has child regexp match for '#{config[:check_child]}'"
+          else
+            critical "#{config[:znode]} doesn't have child regexp match for '#{config[:check_child]}'"
+          end
         else
           critical "#{config[:znode]} value didn't match regexp '#{config[:check_value]}'"
         end

--- a/lib/sensu-plugins-zookeeper/version.rb
+++ b/lib/sensu-plugins-zookeeper/version.rb
@@ -2,7 +2,7 @@ module SensuPluginsZookeeper
   module Version
     MAJOR = 2
     MINOR = 0
-    PATCH = 0
+    PATCH = 1
 
     VER_STRING = [MAJOR, MINOR, PATCH].compact.join('.')
   end


### PR DESCRIPTION
#### Purpose
We need the ability to search an array of sub-nodes to see if a string exists.  For example, we have the following tree structure:

```
/
+-- company
    +-- registry
        +-- by-host
        |   +-- 10.1.1.1
        |   |   +-- service1_1.2.3
        |   |   +-- service2_5.0.1
        |   +-- 10.1.1.2
            |   +-- service1_1.3.4
            |   +-- service2_5.0.2
```

Example search:

`./check-znode.rb -s zk1:2181,1zk2:2181,zk3:2181 -z /company/registry/by-host/10.1.1.1 -c service1`

#### Known Compatibility Issues
You won't be able to search on znode value and for a regex of a sub-node