### PR TITLE
Grab `mntr` output stats by name instead of line number in Zookeeper checks

### DIFF
--- a/bin/check-zookeeper-file-descriptors.rb
+++ b/bin/check-zookeeper-file-descriptors.rb
@@ -70,7 +70,7 @@ class CheckZookeeperREQS < Sensu::Plugin::Check::CLI
       end
 
       result = ready.first.first.read.chomp.split("\n")
-      avg_fd = (result[13].split("\t")[1].to_f / result[14].split("\t")[1].to_f)
+      avg_fd = (result.grep(/zk_open_file_descriptor_count/)[0].split("\t")[1].to_f / result.grep(/zk_max_file_descriptor_count/)[0].split("\t")[1].to_f)
 
       ok %(Zookeeper's open file descriptors rate is #{avg_fd}) if avg_fd < config[:fd_critical]
       critical %(Zookeeper's open file descriptors rate is #{avg_fd}, which is more than #{config[:fd_critical]} threshold)

--- a/bin/check-zookeeper-latency.rb
+++ b/bin/check-zookeeper-latency.rb
@@ -67,7 +67,7 @@ class CheckZookeeperREQS < Sensu::Plugin::Check::CLI
       end
 
       result = ready.first.first.read.chomp.split("\n")
-      avg_latency = result[1].split("\t")[1].to_i
+      avg_latency = result.grep(/zk_avg_latency/)[0].split("\t")[1].to_i
 
       ok %(Zookeeper has average latency #{avg_latency}) if avg_latency < config[:avg_latency_critical]
       critical %(Zookeeper's average latency is #{avg_latency}, which is more than #{config[:avg_latency_critical]} threshold)

--- a/bin/check-zookeeper-reqs.rb
+++ b/bin/check-zookeeper-reqs.rb
@@ -70,7 +70,7 @@ class CheckZookeeperREQS < Sensu::Plugin::Check::CLI
       end
 
       result = ready.first.first.read.chomp.split("\n")
-      out_reqs = result[7].split("\t")[1].to_i
+      out_reqs = result.grep(/zk_outstanding_requests/)[0].split("\t")[1].to_i
 
       ok %(Zookeeper has #{out_reqs} outstanding requests) if out_reqs < config[:out_reqs_critical]
       critical %(Zookeeper has #{out_reqs} outstanding requests, which is more than #{config[:out_reqs_critical]} threshold)

--- a/sensu-plugins-zookeeper.gemspec
+++ b/sensu-plugins-zookeeper.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |s| # rubocop:disable Metrics/BlockLength
   s.add_runtime_dependency 'sensu-plugin', '~> 1.2'
   s.add_runtime_dependency 'zookeeper',    '1.4.11'
 
-  s.add_development_dependency 'bundler',                   '~> 2.1'
+  s.add_development_dependency 'bundler',                   '~> 1.7'
   s.add_development_dependency 'codeclimate-test-reporter', '~> 1.0'
   s.add_development_dependency 'github-markup',             '~> 3.0'
   s.add_development_dependency 'pry',                       '~> 0.10'

--- a/sensu-plugins-zookeeper.gemspec
+++ b/sensu-plugins-zookeeper.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |s| # rubocop:disable Metrics/BlockLength
   s.add_runtime_dependency 'sensu-plugin', '~> 1.2'
   s.add_runtime_dependency 'zookeeper',    '1.4.11'
 
-  s.add_development_dependency 'bundler',                   '~> 1.7'
+  s.add_development_dependency 'bundler',                   '~> 2.1'
   s.add_development_dependency 'codeclimate-test-reporter', '~> 1.0'
   s.add_development_dependency 'github-markup',             '~> 3.0'
   s.add_development_dependency 'pry',                       '~> 0.10'


### PR DESCRIPTION
#### Purpose

In Zookeeper 3.6.0, `echo mntr | nc localhost 2181` outputs a lot more stats and in a different order when compared to the previous versions. Checks such as `check-zookeeper-latency.rb`, `check-zookeeper-file-descriptors.rb` and `check-zookeeper-reqs.rb` give wrong results because they are fetching stats from this command's output using hardcoded line numbers:

Example: In `check-zookeeper-reqs.rb` we have:

`out_reqs = result[7].split("\t")[1].to_i`

which with Zookeeper 3.6.0 will fetch stat `zk_max_file_descriptor_count` instead of the desired `zk_outstanding_requests`.

By using the stat name instead we guarantee to fetch the desired value.
