### PR TITLE
Relax zookeeper requirement from 1.4.11 to ~> 1.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,12 @@ cache:
 - bundler
 install:
 - bundle install
-rvm:
-- 2.3.0
-- 2.4.1
+jobs:
+  include:
+  - rvm: 2.3.0
+  - rvm: 2.4.1
+  - rvm: 2.7.0
+    dist: focal
 notifications:
   email:
     recipients:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ Which is based on [Keep A Changelog](http://keepachangelog.com/)
 
 ## [Unreleased]
 
+### Fixed
+- `sensu-plugins-zookeeper.gemspec`: Relax zookeeper requirement from 1.4.11 to ~> 1.4 to incorporate an [installation bug](https://github.com/zk-ruby/zookeeper/issues/85) [fix](https://github.com/zk-ruby/zookeeper/pull/97) (@jonathanschlue-as)
+
 ## [3.1.0] - 2021-03-31
 
 ### Changes

--- a/sensu-plugins-zookeeper.gemspec
+++ b/sensu-plugins-zookeeper.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |s| # rubocop:disable Metrics/BlockLength
   s.version                = SensuPluginsZookeeper::Version::VER_STRING
 
   s.add_runtime_dependency 'sensu-plugin', '~> 4.0'
-  s.add_runtime_dependency 'zookeeper',    '1.4.11'
+  s.add_runtime_dependency 'zookeeper',    '~> 1.4'
 
   s.add_development_dependency 'bundler',                   '~> 2.1'
   s.add_development_dependency 'codeclimate-test-reporter', '~> 1.0'


### PR DESCRIPTION
## Pull Request Checklist

**Is this in reference to an existing issue?**

Fixes: https://github.com/sensu-plugins/sensu-plugins-zookeeper/issues/39

#### General

- [x] Update Changelog following the conventions laid out on [Our CHANGELOG Guidelines ](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)
- [x] Update README with any necessary configuration snippets
- [x] Binstubs are created if needed
- [x] RuboCop passes
- [x] Existing tests pass

#### New Plugins

n/a

#### Purpose

* Incorporate upstream fixes
  * Fix #39

#### Known Compatibility Issues

None so far. If desired, ubuntu focal / gcc 9 could be added as a CI runner if such a pipeline exists.

However, compatibility with existing installations using zookeeper `1.4.11` is given as those are still compliant with the new version spec of `~> 1.4`.
